### PR TITLE
Copy the 'util' dir to nginx, which contains the JS required for Ledger signing

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,4 +5,5 @@ ENV GIT_URL https://github.com/kadena-community/kadena-transfer-js.git
 RUN apt-get -y update \
 && apt-get -y install git \
 && git clone ${GIT_URL} \
-&& cp -r /kadena-transfer-js/docs/* /usr/share/nginx/html
+&& cp -r /kadena-transfer-js/docs/* /usr/share/nginx/html \
+&& cp -r /kadena-transfer-js/util /usr/share/nginx/html


### PR DESCRIPTION
This fixes the 404 of
https://transfer.chainweb.com/util/ledger-os.js and https://transfer.chainweb.com/util/httptransp.js