### PR TITLE
Change derivation mode

### DIFF
--- a/docs/ledger.html
+++ b/docs/ledger.html
@@ -51,7 +51,7 @@
             <div style="display: flex; flex-direction: column; width: fit-content" class="buttons">
               <a href="transfer-ledger-create.html"><button id="submit-button" class="ui primary button">Simple Transfer</button></a>
               <a href="sign-ledger-json.html"><button id="transfer-button" class="ui primary button">Sign Transactions (JSON)</button></a>
-              <a href="ledger-keys.html"><button id="xchain-button" class="ui primary button">Search Ledger Keys</button></a>
+              <a href="search-ledger-keys.html"><button id="xchain-button" class="ui primary button">Search Ledger Keys</button></a>
             </div>
           </div>
     </div>

--- a/docs/search-ledger-keys.html
+++ b/docs/search-ledger-keys.html
@@ -6,6 +6,7 @@
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/semantic-ui@2.4.2/dist/semantic.min.css">
   <script src="https://cdn.jsdelivr.net/npm/semantic-ui@2.4.2/dist/semantic.min.js"></script>
   <script src="../util/ledger-os.js"></script>
+  <script src="../util/ledger.js"></script>
   <script src="../util/httptransp.js"></script>
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
@@ -19,7 +20,7 @@
     function toggleSearch(name) {
       if (!searching) return start(name);
       const wasSearching = searching;
-      stop(searching);
+      stopSearch(searching);
       if (wasSearching === name) return;
       setTimeout(() => toggleSearch(name), 1100);
     }
@@ -32,11 +33,16 @@
       }
     }
 
-    function stop(name) {
+    function stopSearch(name) {
       switch(name) {
         case 'specific': return stopSearchSpecific();
         case 'prefix': return stopSearchPrefix();
-        default: console.log('Unknown job to stop:', name);
+        case 'all':
+          stopSearchPrefix();
+          stopSearchSpecific();
+          break;
+        default:
+          console.error('Unknown job to stop:', name);
       }
     }
 
@@ -80,24 +86,6 @@
       }
     }
 
-    const BIP32_PATH_PREFIX = "m/44'/626'/0'/0/";
-    function getPath(keyId) {
-      return `${BIP32_PATH_PREFIX}${keyId}"`;
-    }
-
-    function bufferToHex (buffer) {
-      return [...new Uint8Array (buffer)]
-        .map (b => b.toString (16).padStart (2, "0"))
-        .join ("");
-    }
-
-    async function getLedger(){
-      if (!window.ledger) {
-        var transp = await window.TranspWeb.create();
-        window.ledger = new window.Kadena(transp);
-      }
-    }
-
     function copyPrefixResults(elem) {
       const str = res.map(([n, key]) => `Key ${n}: ${key}`).join('\n');
       navigator.clipboard.writeText(str);
@@ -107,30 +95,33 @@
       icon.classList.add("checkmark");
     }
 
+    // used to copy keys
     let res = [];
     async function search(name, key, pred, once = true) {
+      res = [];
       searching = name;
       let i = -1;
       await getLedger();
       let suffix = '';
+      let legacyStr = getLegacyDerivationModeFromLocation() ? '(Legacy) ' : '';
       while(searching) {
         i++;
         try {
           const shortKey = key.slice(0, 6)+'..'+key.slice(-6);
-          setStatus(name, `Searching for:<br/>${key}<br/><br/>Looking in slot: ${i}<div class="rel">${suffix}</div>`, suffix ? 'green' : 'yellow');
+          setStatus(name, `${legacyStr}Searching for:<br/>${key}<br/><br/>Looking in slot: ${i}<div class="rel">${suffix}</div>`, suffix ? 'green' : 'yellow');
           const publicKey = bufferToHex((await window.ledger.getPublicKey(getPath(i))).publicKey);
           // not the key we are looking for. continue
           if (!pred(publicKey)) continue;
           // found and we only care about one key. finish it
           if (once) {
             searching = false;
-            setStatus(name, `<strong>Found</strong><br/><strong>Slot: ${i}</strong><br/>Path: ${getPath(i)}<br/>Key: ${publicKey}`, 'green');
+            setStatus(name, `<strong>Found</strong><br/><strong>${legacyStr}Slot: ${i}</strong><br/>Path: ${getPath(i)}<br/>Key: ${publicKey}`, 'green');
             reset();
             break;
           }
           // found but we keep looking
           suffix = suffix ? suffix : '<div class="ui divider"></div><strong style="text-decoration: underline">Found</strong><br/><button onclick="copyPrefixResults(this)" type="button" id="copybtn" class="circular topright ui icon button"><i class="icon copy"></i></button>';
-          suffix += `<strong>Slot ${i}</strong> (${getPath(i)})<br/>${publicKey}<br/><br/>`;
+          suffix += `<strong>${legacyStr}Slot ${i}</strong> (${getPath(i)})<br/>${publicKey}<br/><br/>`;
           res.push([i, publicKey]);
         } catch(e) {
           searching = false;
@@ -241,6 +232,17 @@
             <a onclick="prefixTemplate('all')">All</a>
           </p>
           <div class="ui raised segment" style="display: none" id="prefix-status"></div>
+        </div>
+
+        <div class="ui segment">
+          <h4 class="ui header">Options</h4>
+          <div class="ui message">
+            <p>Key derivation has changed since the first version of this tool.</p>
+            <p><strong>If you used this tool to access accounts in October 2023:</strong></p>
+            <p>You can enable <strong>Legacy mode</strong> which will allow you to access your keys.</p>
+            <p><i>Note: The default (zero) account is not affected by this change.</i></p>
+            <button type="button" class="ui button" id="legacyDerivation-btn">Legacy mode OFF</button>
+          </div>
         </div>
       </form>
 

--- a/docs/search-ledger-keys.html
+++ b/docs/search-ledger-keys.html
@@ -209,7 +209,8 @@
 <body>
   <div id="main">
     <div class="ui container">
-      <img src="https://explorer.chainweb.com/static/1lv9xhxyhlqc262kffl55w08ms1cvxsnrv49zhvm0b799dsi0v0i-kadena-k-logo.png" class="center" style="height:70px">
+      <a href="/"><img src="https://explorer.chainweb.com/static/1lv9xhxyhlqc262kffl55w08ms1cvxsnrv49zhvm0b799dsi0v0i-kadena-k-logo.png" class="center" style="height:70px"></a>
+
       <h1>Kadena Search Ledger Keys</h1>
 
       <form id="kadena-form" class="ui form">

--- a/docs/sign-ledger-json.html
+++ b/docs/sign-ledger-json.html
@@ -389,7 +389,7 @@
 <body>
   <div id="main">
     <div class="ui container">
-      <img src="https://explorer.chainweb.com/static/1lv9xhxyhlqc262kffl55w08ms1cvxsnrv49zhvm0b799dsi0v0i-kadena-k-logo.png" class="center" style="height:70px">
+      <a href="/"><img src="https://explorer.chainweb.com/static/1lv9xhxyhlqc262kffl55w08ms1cvxsnrv49zhvm0b799dsi0v0i-kadena-k-logo.png" class="center" style="height:70px"></a>
       <h1>Kadena Sign with Ledger</h1>
       <div id="kadena-warning" class="ui warning message">
         <i class="close icon"></i>

--- a/docs/sign-ledger-json.html
+++ b/docs/sign-ledger-json.html
@@ -6,6 +6,7 @@
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/semantic-ui@2.4.2/dist/semantic.min.css">
     <script src="https://cdn.jsdelivr.net/npm/semantic-ui@2.4.2/dist/semantic.min.js"></script>
     <script src="../util/ledger-os.js"></script>
+    <script src="../util/ledger.js"></script>
     <script src="../util/httptransp.js"></script>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
@@ -48,39 +49,9 @@
 
       // INITIATION FUNCTIONS
       window.addEventListener('load', function (event) {
-        let prevTimeout;
-        document.getElementById("keyIdDropdown").addEventListener("change", async function(e){
-          // debounce - when typing we sometimes get multiple triggers
-          if (prevTimeout)
-            clearTimeout(prevTimeout);
-          prevTimeout = setTimeout(() => {
-            prevTimeout = null;
-            getPublicKeyFromLedger()
-          }, 200);
-        })
-        document.getElementById("getSig-button").addEventListener("click", async function(e){
-          if (!window.pubKey) {
-            await getPublicKeyFromLedger();
-          }
-          if (window.pubKey) {
-            dimBody("Waiting for ledger signature");
-            await signWithLedger();
-            $("body").dimmer("hide");
-          }
-        });
         document.getElementById("submit-button").addEventListener("click", function(){
           submit();
         });
-        document.getElementById("getPubkey-button").addEventListener("click", async function(e){
-          await getPublicKeyFromLedger();
-        });
-
-        document.getElementById("verifyAddress-button").addEventListener("click", async function(e){
-          // Dont dim, let the user see the address on web
-          setStatus('Check your ledger to confirm your address');
-          await verifyAddressOnLedger();
-          setStatus('');
-        })
 
         document.getElementById("reset-button").addEventListener("click", function(event){
           reset();
@@ -102,28 +73,11 @@
           return false;
         })
 
-        if (navigator.userAgent.indexOf(' Firefox') > -1) {
-          setError('It seems that you are using Firefox, which does not support the technology required to interact with a Ledger via this page. Try using a different browser.');
-        }
-
       });
 
       function dimBody(msg){
         $("body").dimmer({closable:true}).dimmer("show");
         $(".dimmer").html("<div class='content'> <h3> " + msg + "</h3></div>");
-      }
-
-      async function getLedger(){
-        if (!window.ledger) {
-          var transp = await window.TranspWeb.create();
-          window.ledger = new window.Kadena(transp);
-        }
-      }
-
-      const BIP32_PATH_PREFIX = "m/44'/626'/0'/0/";
-      function getPath() {
-        const {keyId} = getInputs();
-        return `${BIP32_PATH_PREFIX}${keyId}"`;
       }
 
       async function signWithLedger(){
@@ -215,41 +169,6 @@
         let content = document.getElementById("getPubkey-content");
         title.classList.add('active')
         content.classList.add('active')
-      }
-
-      function bufferToHex (buffer) {
-        return [...new Uint8Array (buffer)]
-          .map (b => b.toString (16).padStart (2, "0"))
-          .join ("");
-      }
-
-      async function getPublicKeyFromLedger(){
-        dimBody("Waiting for ledger public key");
-        setPublicKey('');
-        setStatus('Loading');
-        await getLedger();
-        try {
-          var publicKey = bufferToHex((await window.ledger.getPublicKey(getPath())).publicKey);
-          setPublicKey(publicKey);
-          setStatus();
-        } catch (e) {
-          setStatus('Error: '+e.message);
-          console.error(e);
-          setError("Could not get the Ledger Account Name " + e.message)
-        }
-        $("body").dimmer("hide");
-      }
-
-      async function verifyAddressOnLedger(){
-        await getLedger();
-        try {
-          var path = getPath();
-          var publicKey = bufferToHex((await window.ledger.verifyAddress(path)).publicKey);
-          setPublicKey(publicKey);
-        } catch (e) {
-          console.error(e);
-          setError("Could not get the Ledger Account Name "+e.message);
-        }
       }
 
       function reset(){
@@ -355,6 +274,7 @@
 
       function getInputs (){
         return {
+          legacyDerivationMode: getLegacyDerivationModeFromLocation(),
           keyId: document.getElementById("keyId").value,
           json: document.getElementById("json").value,
         }
@@ -404,35 +324,7 @@
           account works as expected.
         </p>
       </div>
-      <div>
-        <div class="ui accordion">
-          <div class="title" id="getPubkey-button">
-            <i class="dropdown icon"></i>
-            Change/Verify Ledger Account Name
-          </div>
-          <div class="content" id="getPubkey-content">
-            <div class="ui message" style="margin-bottom:10px">
-              <div>
-                <div id="keyIdDropdown" class="ui floating small dropdown labeled search icon button">
-                  <input type="hidden" id="keyId" value="0" />
-                  <i class="key icon"></i>
-                  <div class="text">0</div>
-                  <div class="menu" id="ledger-key-menu">
-                  </div>
-                </div>
-                <i style="margin-right: -20px; margin-left: 5px" class="info icon small popup-target" data-content="Change ledger key. If unsure, leave the default (zero)."></i>
-              </div>
-
-              <p style="font-weight:bold;" id="fromAccount"></p>
-              <p style="font-weight:bold;" id="status"></p>
-
-              <div class="ui button" id="verifyAddress-button">
-                <i class="eye icon"></i>
-                <span>Verify</span>
-              </div>
-            </div>
-          </div>
-        </div>
+      <div class="ui accordion" id="change-ledger-key-accordion">
       </div>
       <form id ="kadena-form" class="ui form" autocomplete="off">
         You can use this form to sign JSON encoded transactions using your Ledger.

--- a/docs/sign-ledger-json.html
+++ b/docs/sign-ledger-json.html
@@ -298,10 +298,10 @@
           account works as expected.
         </p>
       </div>
+      <p><strong>You can use this form to sign JSON encoded transactions using your Ledger.</strong></p>
       <div class="ui accordion" id="change-ledger-key-accordion">
       </div>
       <form id ="kadena-form" class="ui form" autocomplete="off">
-        You can use this form to sign JSON encoded transactions using your Ledger.
         <div class="field">
           <textarea placeholder="JSON encoded transaction goes here" rows="10" id="json"></textarea>
         </div>

--- a/docs/sign-ledger-json.html
+++ b/docs/sign-ledger-json.html
@@ -107,16 +107,20 @@
         }
       }
 
-      function showSubmit(message = '') {
+      function showSubmit() {
         const submit = document.getElementById('submit-button');
         submit.classList.remove('disabled');
         submit.classList.add('primary');
       }
 
-      function resetSubmit(message) {
+      function disableSubmit() {
         const submit = document.getElementById('submit-button');
         submit.classList.add('disabled');
         submit.classList.remove('primary');
+      }
+
+      function resetSubmit(message) {
+        disableSubmit();
         const notice = document.getElementById('submit-notice');
         if (message) {
           notice.style.display = 'block';
@@ -153,6 +157,7 @@
         setStatus('');
         clearError();
         document.getElementById('signature').value = '';
+        document.getElementById('json').value = '';
         document.getElementById('getSig-button').classList.remove('disabled');
         document.getElementById('getSig-button').innerText = 'Sign with Ledger';
         document.getElementById('status-box').classList.add("hidden")
@@ -186,6 +191,7 @@
       }
 
       async function submit() {
+        disableSubmit();
         clearError();
         const { chainId } = cmd.meta;
         const { host, networkId } = getNode(chainId);

--- a/docs/sign-ledger-json.html
+++ b/docs/sign-ledger-json.html
@@ -11,32 +11,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
     <script>
-
-      //Form Validation
-      $(document).ready(function(){
-
-        // create 1000 entries under "ledger key"
-        const m = $('#ledger-key-menu');
-        for(let i=0; i<=1000; i++) {
-          m.append(`<div class="item" data-value="${i}">${i}</div>`);
-        }
-
-        //Activate Ledger Dropdown
-        $('.dropdown')
-          .dropdown({ selectOnKeydown: false });
-
-        $('.popup-target')
-          .popup({ closable: false});
-
-        $('.message .close')
-          .on('click', function() {
-            $(this)
-              .closest('.message')
-              .transition('fade')
-            ;
-          });
-      });
-
       const mkReq = (cmd) => {
         return {
           headers: {

--- a/docs/transfer-create.html
+++ b/docs/transfer-create.html
@@ -821,7 +821,8 @@
 <body>
     <div id="main">
         <div class="ui container">
-            <img src="https://explorer.chainweb.com/static/1lv9xhxyhlqc262kffl55w08ms1cvxsnrv49zhvm0b799dsi0v0i-kadena-k-logo.png" class="center" style="height:70px">
+            <a href="/"><img src="https://explorer.chainweb.com/static/1lv9xhxyhlqc262kffl55w08ms1cvxsnrv49zhvm0b799dsi0v0i-kadena-k-logo.png" class="center" style="height:70px"></a>
+
             <h1>Kadena Coin Transfer</h1>
             <div id="kadena-warning" class="ui warning message">
               <i class="close icon"></i>

--- a/docs/transfer-ledger-create.html
+++ b/docs/transfer-ledger-create.html
@@ -17,12 +17,6 @@
       //Form Validation
       $(document).ready(function(){
 
-        // create 1000 entries under "ledger key"
-        const m = $('#ledger-key-menu');
-        for(let i=0; i<=1000; i++) {
-          m.append(`<div class="item" data-value="${i}">${i}</div>`);
-        }
-
         // custom form validation rule
         $.fn.form.settings.rules.validSig = function(sig) {
           return sig.length === 128 && validateSig(sig);
@@ -99,20 +93,6 @@
           $(`.ui .segment #${e.target.id}-input`).attr("hidden", false)
         });
 
-        //Activate Dropdown
-        $('.dropdown')
-          .dropdown({ selectOnKeydown: false });
-
-        $('.popup-target')
-          .popup({ closable: false});
-
-        $('.message .close')
-          .on('click', function() {
-            $(this)
-              .closest('.message')
-              .transition('fade')
-            ;
-          });
       });
 
       const mkReq = (cmd) => {

--- a/docs/transfer-ledger-create.html
+++ b/docs/transfer-ledger-create.html
@@ -704,8 +704,8 @@
 <body>
   <div id="main">
     <div class="ui container">
-      <img src="https://explorer.chainweb.com/static/1lv9xhxyhlqc262kffl55w08ms1cvxsnrv49zhvm0b799dsi0v0i-kadena-k-logo.png" class="center" style="height:70px">
-      <h1>Kadena Coin Transfer</h1>
+      <a href="/"><img src="https://explorer.chainweb.com/static/1lv9xhxyhlqc262kffl55w08ms1cvxsnrv49zhvm0b799dsi0v0i-kadena-k-logo.png" class="center" style="height:70px"></a>
+      <h1>Kadena Ledger Transfer</h1>
       <div id="kadena-warning" class="ui warning message">
         <i class="close icon"></i>
         <div class="header">

--- a/docs/transfer-ledger-create.html
+++ b/docs/transfer-ledger-create.html
@@ -8,6 +8,7 @@
     <script src="https://cdn.jsdelivr.net/npm/pact-lang-api@4.1.2/pact-lang-api-global.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/tweetnacl@1.0.3/nacl.min.js"></script>
     <script src="../util/ledger-os.js"></script>
+    <script src="../util/ledger.js"></script>
     <script src="../util/httptransp.js"></script>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
@@ -97,6 +98,7 @@
           $(`.ui .segment .field`).attr("hidden", true)
           $(`.ui .segment #${e.target.id}-input`).attr("hidden", false)
         });
+
         //Activate Dropdown
         $('.dropdown')
           .dropdown({ selectOnKeydown: false });
@@ -125,37 +127,6 @@
 
       // INITIATION FUNCTIONS
       window.addEventListener('load', function (event) {
-        let prevTimeout;
-        document.getElementById("keyIdDropdown").addEventListener("change", async function(e){
-          // debounce - when typing we sometimes get multiple triggers
-          if (prevTimeout)
-            clearTimeout(prevTimeout);
-          prevTimeout = setTimeout(() => {
-            prevTimeout = null;
-            getPublicKeyFromLedger()
-          }, 200);
-        })
-        document.getElementById("getSig-button").addEventListener("click", async function(e){
-          dimBody("Waiting for ledger signature");
-          await signWithLedger();
-          $("body").dimmer("hide");
-        })
-        document.getElementById("getBlindSig-button").addEventListener("click", async function(e){
-          dimBody("Waiting for ledger signature");
-          await signHashWithLedger();
-          $("body").dimmer("hide");
-        })
-
-        document.getElementById("getPubkey-button").addEventListener("click", async function(e){
-          await getPublicKeyFromLedger();
-        })
-
-        document.getElementById("verifyAddress-button").addEventListener("click", async function(e){
-          // Dont dim, let the user see the address on web
-          setStatus('Check your ledger to confirm your address');
-          await verifyAddressOnLedger();
-          setStatus('');
-        })
 
         document.getElementById("network-0").addEventListener("click", async function(e){
           reset();
@@ -183,14 +154,16 @@
           reset();
         })
 
+        document.getElementById("getBlindSig-button").addEventListener("click", async function(e){
+          dimBody("Waiting for ledger signature");
+          await signHashWithLedger();
+          $("body").dimmer("hide");
+        })
+
         document.getElementById("showBlindSigning-button").addEventListener("click", async function(e){
           document.getElementById("showBlindSigning-button").hidden = true;
           document.getElementById("kadena-blind-sign-form-top").hidden = false;
         })
-
-        if (navigator.userAgent.indexOf(' Firefox') > -1) {
-          setError('It seems that you are using Firefox, which does not support the technology required to interact with a Ledger via this page. Try using a different browser.');
-        }
 
       });
 
@@ -208,19 +181,6 @@
       function dimBody(msg){
         $("body").dimmer({closable:true}).dimmer("show");
         $(".dimmer").html("<div class='content'> <h3> " + msg + "</h3></div>");
-      }
-
-      async function getLedger(){
-        if (!window.ledger) {
-          var transp = await window.TranspWeb.create();
-          window.ledger = new window.Kadena(transp);
-        }
-      }
-
-      const BIP32_PATH_PREFIX = "m/44'/626'/0'/0/";
-      function getPath() {
-        const {keyId} = getInputs();
-        return `${BIP32_PATH_PREFIX}${keyId}"`;
       }
 
       async function signWithLedger(){
@@ -318,44 +278,7 @@
         document.getElementById("publicKey").value = [ publicKey ];
         document.getElementById("fromAccount").innerText = publicKey ? `k:${publicKey}` : '';
         window.pubKey = publicKey;
-        let title = document.getElementById("getPubkey-button");
-        let content = document.getElementById("getPubkey-content");
-        title.classList.add('active')
-        content.classList.add('active')
-      }
-
-      function bufferToHex (buffer) {
-        return [...new Uint8Array (buffer)]
-          .map (b => b.toString (16).padStart (2, "0"))
-          .join ("");
-      }
-
-      async function getPublicKeyFromLedger(){
-        dimBody("Waiting for ledger public key");
-        setPublicKey('');
-        setStatus('Loading');
-        await getLedger();
-        try {
-          var publicKey = bufferToHex((await window.ledger.getPublicKey(getPath())).publicKey);
-          setPublicKey(publicKey);
-          setStatus();
-        } catch (e) {
-          setStatus('Error: '+e.message);
-          setError("Could not get the Ledger Account Name " + e.message)
-        }
-        $("body").dimmer("hide");
-      }
-
-      async function verifyAddressOnLedger(){
-        await getLedger();
-        try {
-          var path = getPath();
-          var publicKey = bufferToHex((await window.ledger.verifyAddress(path)).publicKey);
-          setPublicKey(publicKey);
-        } catch (e) {
-          console.error(e);
-          setError("Could not get the Ledger Account Name "+e.message);
-        }
+        showAccordion(document.getElementById("getPubkey-button").parentNode);
       }
 
       function reset(){
@@ -657,6 +580,7 @@
 
       const getInputs = function (){
         return {
+          legacyDerivationMode: getLegacyDerivationModeFromLocation(),
           keyId: document.getElementById("keyId").value,
           fromAccount: document.getElementById("fromAccount").innerText,
           fromChainId: document.getElementById("fromChainId").value,
@@ -719,35 +643,7 @@
           account works as expected.
         </p>
       </div>
-      <div>
-        <div class="ui accordion">
-          <div class="title" id="getPubkey-button">
-            <i class="dropdown icon"></i>
-            Change/Verify Ledger Account Name
-          </div>
-          <div class="content" id="getPubkey-content">
-            <div class="ui message" style="margin-bottom:10px">
-              <div>
-                <div id="keyIdDropdown" class="ui floating small dropdown labeled search icon button">
-                  <input type="hidden" id="keyId" value="0" />
-                  <i class="key icon"></i>
-                  <div class="text">0</div>
-                  <div class="menu" id="ledger-key-menu">
-                  </div>
-                </div>
-                <i style="margin-right: -20px; margin-left: 5px" class="info icon small popup-target" data-content="Change ledger key. If unsure, leave the default (zero)."></i>
-              </div>
-
-              <p style="font-weight:bold;" id="fromAccount"></p>
-              <p style="font-weight:bold;" id="status"></p>
-
-              <div class="ui button" id="verifyAddress-button">
-                <i class="eye icon"></i>
-                <span>Verify</span>
-              </div>
-            </div>
-          </div>
-        </div>
+      <div class="ui accordion" id="change-ledger-key-accordion">
       </div>
       <form id ="kadena-form" class="ui form" autocomplete="off">
         <div class="field">
@@ -886,6 +782,7 @@
           <p>
             <b>Signing hashes from untrusted sources can lead to loss of funds.</b><br />
             Transaction hash signing (Blind Signing) feature is intended only for advanced users.<br/>
+            <b>You must ALWAYS validate that the hash you are signing matches the expected transaction.</b><br />
             This function requires 'Blind Signing' to be enabled on the Kadena Ledger App.
           </p>
         </div>

--- a/docs/util/ledger.js
+++ b/docs/util/ledger.js
@@ -1,0 +1,219 @@
+function showAccordion(node) {
+    const title = node.querySelector('& > .title')
+    const content = node.querySelector('& > .content')
+    if (title) {
+        title.classList.add('active');
+    }
+    if (content) {
+        content.classList.add('active');
+    }
+}
+
+function hideAccordion(node) {
+    const title = node.querySelector('& > .title')
+    const content = node.querySelector('& > .content')
+    if (title) {
+        title.classList.remove('active');
+    }
+    if (content) {
+        content.classList.remove('active');
+    }
+}
+
+async function onLoadDerivationMode() {
+    const { legacyDerivationMode } = getInputs();
+    if (legacyDerivationMode) {
+        const outer = document.getElementById('getPubkey-button');
+        const inner = document.getElementById('showDerivationOption-button');
+        showAccordion(outer.parentNode);
+        showAccordion(inner.parentNode);
+        updateDerivationButton();
+        await getPublicKeyFromLedger();
+    }
+}
+
+function getLegacyDerivationModeFromLocation() {
+    return new URLSearchParams(window.location.search).get("derivation") === 'legacy';
+}
+
+function updateDerivationButton() {
+    const { legacyDerivationMode } = getInputs();
+    const btn = document.getElementById('legacyDerivation-btn');
+    if (legacyDerivationMode) {
+        btn.classList.add('orange');
+        btn.innerText = 'Legacy mode ON'
+    } else {
+        btn.classList.remove('orange');
+        btn.innerText = 'Legacy mode OFF'
+    }
+}
+
+async function switchDerivationMode() {
+    const { legacyDerivationMode } = getInputs();
+    const location = new URL(window.location.href);
+    if (!legacyDerivationMode) {
+        location.searchParams.set('derivation', 'legacy');
+    } else {
+        location.searchParams.delete('derivation');
+    }
+    if (location.toString() !== window.location.href) {
+        window.history.pushState(null, null, location.toString());
+    }
+    updateDerivationButton();
+    await getPublicKeyFromLedger();
+}
+
+async function getLedger() {
+    if (!window.ledger) {
+        var transp = await window.TranspWeb.create();
+        window.ledger = new window.Kadena(transp);
+    }
+}
+
+const BIP32_PATH_PREFIX = "";
+function getPath() {
+    const { keyId, legacyDerivationMode } = getInputs();
+    if (legacyDerivationMode) {
+        return `m/44'/626'/0'/0/${keyId}`;
+    }
+    return `m/44'/626'/${keyId}'`;
+}
+
+function bufferToHex (buffer) {
+    return [...new Uint8Array (buffer)]
+        .map (b => b.toString (16).padStart (2, "0"))
+        .join ("");
+}
+
+async function getPublicKeyFromLedger(){
+    dimBody("Waiting for ledger public key");
+    setPublicKey('');
+    setStatus('Loading');
+    await getLedger();
+    try {
+        var publicKey = bufferToHex((await window.ledger.getPublicKey(getPath())).publicKey);
+        setPublicKey(publicKey);
+        setStatus();
+    } catch (e) {
+        setStatus('Error: '+e.message);
+        setError("Could not get the Ledger Account " + e.message)
+    }
+    $("body").dimmer("hide");
+}
+
+async function verifyAddressOnLedger(){
+    await getLedger();
+    try {
+        var path = getPath();
+        var publicKey = bufferToHex((await window.ledger.verifyAddress(path)).publicKey);
+        setPublicKey(publicKey);
+    } catch (e) {
+        console.error(e);
+        setError("Could not get the Ledger Account "+e.message);
+    }
+}
+
+function renderLedgerAccountChangeModal(elemId = 'change-ledger-key-accordion') {
+    document.getElementById(elemId).innerHTML = `
+        <div class="title" id="getPubkey-button">
+          <i class="dropdown icon"></i>
+          Change/Verify Ledger Account
+        </div>
+        <div class="content" id="getPubkey-content">
+          <div class="ui message" style="margin-bottom:10px">
+            <div>
+              <div id="keyIdDropdown" class="ui floating small dropdown labeled search icon button">
+                <input type="hidden" id="keyId" value="0" />
+                <i class="key icon"></i>
+                <div class="text">0</div>
+                <div class="menu" id="ledger-key-menu">
+                </div>
+              </div>
+              <i style="margin-right: -20px; margin-left: 5px" class="info icon small popup-target" data-content="Change ledger key. If unsure, leave the default (zero)."></i>
+            </div>
+
+            <p style="font-weight:bold;" id="fromAccount"></p>
+            <p style="font-weight:bold;" id="status"></p>
+
+            <div class="ui button" id="verifyAddress-button">
+              <i class="eye icon"></i>
+              <span>Verify</span>
+            </div>
+
+            <div class="ui accordion">
+              <div class="title" id="showDerivationOption-button">
+                <i class="dropdown icon"></i>
+                Not the account you were expecting?
+              </div>
+              <div class="content" id="showDerivationOption-button">
+                <div class="ui message">
+                  <p>The first iteration of this tool derived account keys differently.</p>
+                  <p><strong>If you used this tool to access accounts in October 2023:</strong></p>
+                  <p>You can enable <strong>Legacy mode</strong> which will allow you to access your keys.</p>
+                  <p><i>Note: The default (zero) account is not affected by this change.</i></p>
+                  <button class="ui button" id="legacyDerivation-btn">Legacy mode OFF</button>
+                </div>
+              </div>
+            </div>
+
+          </div>
+        </div>`;
+}
+
+window.addEventListener('load', function (event) {
+    renderLedgerAccountChangeModal();
+
+    let prevTimeout;
+    document.getElementById("keyIdDropdown").addEventListener("change", async function(e){
+        // debounce - when typing we sometimes get multiple triggers
+        if (prevTimeout)
+            clearTimeout(prevTimeout);
+        prevTimeout = setTimeout(() => {
+            prevTimeout = null;
+            getPublicKeyFromLedger()
+        }, 200);
+    });
+
+    document.getElementById("getSig-button").addEventListener("click", async function(e){
+        dimBody("Waiting for ledger signature");
+        await signWithLedger();
+        $("body").dimmer("hide");
+    });
+
+    document.getElementById("getPubkey-button").addEventListener("click", async function(e){
+        const content = document.getElementById("getPubkey-content");
+        if (content.classList.contains('active')) {
+            hideAccordion(content.parentNode);
+        } else {
+            showAccordion(content.parentNode);
+            await getPublicKeyFromLedger();
+        }
+    })
+
+    document.getElementById("verifyAddress-button").addEventListener("click", async function(e){
+        // Dont dim, let the user see the address on web
+        setStatus('Check your ledger to confirm your address');
+        await verifyAddressOnLedger();
+        setStatus('');
+    })
+
+    document.getElementById("showDerivationOption-button").addEventListener("click", async function(e){
+        const content = document.getElementById("showDerivationOption-button");
+        if (content.classList.contains('active')) {
+            hideAccordion(content.parentNode);
+        } else {
+            showAccordion(content.parentNode);
+        }
+    })
+
+    document.getElementById("legacyDerivation-btn").addEventListener("click", async function(e){
+        switchDerivationMode();
+    })
+
+    if (navigator.userAgent.indexOf(' Firefox') > -1) {
+        setError('It seems that you are using Firefox, which does not support the technology required to interact with a Ledger via this page. Try using a different browser.');
+    }
+
+    onLoadDerivationMode();
+
+});

--- a/docs/util/ledger.js
+++ b/docs/util/ledger.js
@@ -70,13 +70,12 @@ async function getLedger() {
     }
 }
 
-const BIP32_PATH_PREFIX = "";
 function getPath() {
     const { keyId, legacyDerivationMode } = getInputs();
     if (legacyDerivationMode) {
         return `m/44'/626'/0'/0/${keyId}`;
     }
-    return `m/44'/626'/${keyId}'`;
+    return `m/44'/626'/${keyId}'/0/0`;
 }
 
 function bufferToHex (buffer) {

--- a/docs/xchain.html
+++ b/docs/xchain.html
@@ -17,12 +17,8 @@
 
   <body>
     <div class="ui main container">
-      <img
-        alt="kadena-logo"
-        src="https://explorer.chainweb.com/static/1lv9xhxyhlqc262kffl55w08ms1cvxsnrv49zhvm0b799dsi0v0i-kadena-k-logo.png"
-        class="center"
-        style="height: 70px"
-      />
+      <a href="/"><img src="https://explorer.chainweb.com/static/1lv9xhxyhlqc262kffl55w08ms1cvxsnrv49zhvm0b799dsi0v0i-kadena-k-logo.png" class="center" style="height:70px"></a>
+
 
       <h1>Finish Cross Chain Transfer</h1>
       <form id="kadena-form" class="ui form">


### PR DESCRIPTION
Changes apply to:
- Ledger Simple Transfer
- Ledger Sign JSON Transaction
- Ledger Search Keys

Changes:
- Changes default derivation mode to use the [recommended path for account-based blockchains by Ledger](https://blog.ledger.com/understanding-crypto-addresses-and-derivation-paths/#account-model): `m/44'/626'/$i'/0/0`

- Adds support for legacy derivation mode (previous one used): `m/44'/626'/0'/0/$i`
  - This is in case users have used the tool already and need to access/move funds
  - Legacy mode option source of truth is URL param `derivation=legacy`
    - Loading the pages with that option enabled will expand the accordions so the legacy mode button can be shown in bright orange - intended to prevent accidental use.

- Extracted common ledger functionality to util/ledger.js

- Added option to enter any key number (and tooltip to this effect)
  - Defined list goes up to 99 now that freeform is available

Misc Changes:

- Kadena Icon at top of each page is a link to `/`

Preview: https://change-derivation-mode.kdtjs4taka.pages.dev/sign-ledger-json?derivation=legacy